### PR TITLE
Fix rosdep failure of stomp_plugins package

### DIFF
--- a/stomp_plugins/package.xml
+++ b/stomp_plugins/package.xml
@@ -18,7 +18,7 @@
   <build_depend>stomp_moveit</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>cmake_modules</build_depend>
-  <build_depend>industrial_collision_detection</build_depend>
+  <!--build_depend>industrial_collision_detection</build_depend-->
 
   <run_depend>roscpp</run_depend>
   <run_depend>moveit_ros_planning</run_depend>
@@ -27,12 +27,12 @@
   <run_depend>stomp_moveit</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>cmake_modules</run_depend>
-  <run_depend>industrial_collision_detection</run_depend>
+  <!--run_depend>industrial_collision_detection</run_depend-->
 
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <stomp_moveit plugin="${prefix}/noise_generator_plugins.xml"/>    
+    <stomp_moveit plugin="${prefix}/noise_generator_plugins.xml"/>
     <stomp_moveit plugin="${prefix}/cost_function_plugins.xml"/>
     <stomp_moveit plugin="${prefix}/update_filter_plugins.xml"/>
     <rosdoc config="rosdoc.yaml"/>


### PR DESCRIPTION
Your PR https://github.com/ros-industrial/industrial_moveit/pull/71 is very helpful.
To fix https://github.com/ros-industrial/industrial_moveit/pull/71#issuecomment-400744838 problem, I also comment out `stomp_plugins/package.xml`